### PR TITLE
Add the Date chip parsing.

### DIFF
--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -112,6 +112,9 @@ gdc.config = function(config) {
   if (config.suppressInfo === true) {
     gdc.suppressInfo = true;
   }
+  if (config.formatISODate === true) {
+    gdc.formatISODate = true;
+  }
 };
 
 // Setup for each conversion run.
@@ -371,7 +374,9 @@ var
   INLINE_DRAWING = DocumentApp.ElementType.INLINE_DRAWING,
   INLINE_IMAGE = DocumentApp.ElementType.INLINE_IMAGE,
   UNSUPPORTED = DocumentApp.ElementType.UNSUPPORTED,
-  EQUATION = DocumentApp.ElementType.EQUATION;
+  EQUATION = DocumentApp.ElementType.EQUATION,
+
+  DATE = DocumentApp.ElementType.DATE;
 
   // Heading links and ids gleaned from the TOC, if present.
   gdc.hasToc = false;
@@ -910,6 +915,15 @@ gdc.handleEquation = function() {
   // For now, at least, we should just call out equations in the output.
   gdc.alert('equation: use MathJax/LaTeX if your publishing platform supports it.');
 };
+
+gdc.handleDate = function(child) {
+  let d = child.asDate();
+  if (gdc.formatISODate) {
+    gdc.writeStringToBuffer(d.getTimestamp().toISOString().split("T")[0]);
+  } else {
+    gdc.writeStringToBuffer(d.getDisplayText());
+  }
+}
 
 // Warns/alerts that there are some inline drawings -- no API for that yet :( .
 gdc.handleInlineDrawing = function() {
@@ -1725,6 +1739,9 @@ md.handleChildElement = function(child) {
       break;
     case EQUATION:
       gdc.handleEquation();
+      break;
+    case DATE:
+      gdc.handleDate(child);
       break;
     case UNSUPPORTED:
       gdc.log('child element: UNSUPPORTED');

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -126,6 +126,11 @@ Render HTML tags
 <input type="checkbox" id="suppress_info">
 Suppress top comment
 </label>
+<br>
+<label>
+<input type="checkbox" id="format_iso_date">
+Format dates as YYYY-MM-DD
+</label>
 
 <!-- Docs, bug link. -->
 <br>
@@ -175,6 +180,7 @@ For more details, click the Docs link above.`
     config.wrapHTML = false;
     config.renderHTMLTags = false;
     config.suppressInfo= false;
+    config.formatISODate = false;
 
     // Config settings from UI.
     if (document.getElementById('demote_headings').checked) {
@@ -191,6 +197,9 @@ For more details, click the Docs link above.`
     }
     if (document.getElementById('suppress_info').checked) {
       config.suppressInfo = true;
+    }
+    if (document.getElementById('format_iso_date').checked) {
+      config.formatISODate = true;
     }
 };
     

--- a/html-verification.md
+++ b/html-verification.md
@@ -1,7 +1,9 @@
+<!-- Output copied to clipboard! -->
+
 <!-----
 NEW: Check the "Suppress top comment" option to remove this info from the output.
 
-Conversion time: 1.74 seconds.
+Conversion time: 9.863 seconds.
 
 
 Using this HTML file:
@@ -14,8 +16,8 @@ Using this HTML file:
 Conversion notes:
 
 * Docs to Markdown version 1.0β31
-* Thu Aug 26 2021 12:22:58 GMT-0700 (PDT)
-* Source doc: MAIN: Docs to Markdown (GD2md-html)
+* Sun Mar 20 2022 17:10:44 GMT-0400 (Eastern Daylight Time)
+* Source doc: Copy of dev verification doc (1.0β27 base): Docs to Markdown (gd2md-html)
 * Tables are currently converted to HTML tables.
 
 WARNING:
@@ -759,15 +761,11 @@ Another paragraph with <strong>some bold text</strong>.
 <li>Another list item.
 </li>
 </ol>
-<h2>Horizontal rules</h2>
+<h2>Chips</h2>
 
 
 <p>
-This is a horizontal rule:
-</p>
-<hr>
-<p>
-This is a regular paragraph.
+This is a date: Mar 20, 2022.
 </p>
 <h2 id="bugs">Bugs</h2>
 
@@ -777,11 +775,10 @@ This is a regular paragraph.
 <li>Current open bugs: <a href="https://github.com/evbacher/gd2md-html/issues">https://github.com/evbacher/gd2md-html/issues</a> 
 
 <li>New bug or feature request: <a href="https://github.com/evbacher/gd2md-html/issues/new">https://github.com/evbacher/gd2md-html/issues/new</a>. Thanks for helping to make Docs to Markdown better!
+
+<li>
 </li>
 </ul>
-<p>
-This document ends with a regular paragraph.
-</p>
 
 <!-- Footnotes themselves at the bottom. -->
 

--- a/markdown-verification.md
+++ b/markdown-verification.md
@@ -1,7 +1,9 @@
+<!-- Output copied to clipboard! -->
+
 <!-----
 NEW: Check the "Suppress top comment" option to remove this info from the output.
 
-Conversion time: 1.471 seconds.
+Conversion time: 8.742 seconds.
 
 
 Using this Markdown file:
@@ -14,8 +16,8 @@ Using this Markdown file:
 Conversion notes:
 
 * Docs to Markdown version 1.0β31
-* Thu Aug 26 2021 12:21:46 GMT-0700 (PDT)
-* Source doc: MAIN: Docs to Markdown (GD2md-html)
+* Sun Mar 20 2022 17:08:39 GMT-0400 (Eastern Daylight Time)
+* Source doc: Copy of dev verification doc (1.0β27 base): Docs to Markdown (gd2md-html)
 * Tables are currently converted to HTML tables.
 
 WARNING:
@@ -607,15 +609,10 @@ Another paragraph with **some bold text**.
 1. A numbered list following a terminal subscript.
 2. Another list item.
 
-<h2>Horizontal rules</h2>
+<h2>Chips</h2>
 
 
-This is a horizontal rule:
-
-
----
-
-This is a regular paragraph.
+This is a date: Mar 20, 2022.
 
 <h2 id="bugs">Bugs</h2>
 
@@ -624,9 +621,7 @@ This is a regular paragraph.
 
 * Current open bugs: [https://github.com/evbacher/gd2md-html/issues](https://github.com/evbacher/gd2md-html/issues) 
 * New bug or feature request: [https://github.com/evbacher/gd2md-html/issues/new](https://github.com/evbacher/gd2md-html/issues/new). Thanks for helping to make Docs to Markdown better!
-
-This document ends with a regular paragraph.
-
+* 
 
 <!-- Footnotes themselves at the bottom. -->
 ## Notes


### PR DESCRIPTION
Also add a formatting option formatISODate (in the UI "Format dates as YYYY-MM-DD"); when enabled, formats date chips as YYYY-MM-DD, and when disabled, formats date chips as they're displayed in the document (see https://developers.google.com/apps-script/reference/document/date#getDisplayText()).