### PR TITLE
Support for <pre><code>

### DIFF
--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -112,6 +112,10 @@ gdc.config = function(config) {
   if (config.suppressInfo === true) {
     gdc.suppressInfo = true;
   }
+
+  if (config.usePreCode === true) {
+    gdc.usePreCode = true;
+  } 
 };
 
 // Setup for each conversion run.
@@ -152,6 +156,8 @@ gdc.init = function(docType) {
   gdc.info += '\n\nConversion notes:';
   gdc.info += '\n\n* ' + GDC_TITLE + ' version ' + GDC_VERSION;
   gdc.info += '\n* ' + Date();
+  
+  
 
   // Keep track of numbered lists.
   gdc.listCounters = {};
@@ -191,6 +197,7 @@ gdc.writeBuf = function() {};
 
 // Force H1 -> H2, etc.
 gdc.demoteHeadings = false;
+gdc.usePreCode = false;
 
 // Some state variables for handling lists.
 gdc.ul = 0;

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -27,12 +27,12 @@ var html = html || {
   boldOpen:   '<strong>',
   boldClose:  '</strong>',
   
-  // HTML code blocks (do not add \n at end of <pre>):
-  openCodeBlock:         '\n\n<pre class="prettyprint">',
-  openCodeBlockStart:    '\n\n<pre class="prettyprint lang-',
-  openCodeBlockEnd:      '">',
-  openCodeBlockLangNone: '\n\n<pre>',
-  closeCodeBlock:        '</pre>\n\n',
+  // Defaults for HTML code blocks (do not add \n at end of <pre>):
+openCodeBlock:         '\n\n<pre class="prettyprint">',
+openCodeBlockStart:    '\n\n<pre class="prettyprint lang-',
+openCodeBlockEnd:      '">',
+openCodeBlockLangNone: '\n\n<pre>',
+closeCodeBlock:        '</pre>\n\n',
 
   // non-semantic underline, since Docs supports it.
   underlineStart: '<span style="text-decoration:underline;">',
@@ -46,6 +46,17 @@ html.doHtml = function(config) {
   gdc.useHtml();
   
   gdc.config(config);
+  
+  if (gdc.usePreCode) {
+      //Override for HTML code blocks if use <code><pre> is selected
+      html.openCodeBlock='\n\n<pre class="line-numbers"><code class="language-none">'
+      html.openCodeBlockStart='\n\n<pre class="line-numbers"><code class="language-'
+      html.openCodeBlockEnd='">'
+      html.openCodeBlockLangNone='\n\n<code><pre>'
+      html.closeCodeBlock='</code></pre>\n\n'
+       gdc.info += '\n* codePre:' + gdc.usePreCode.valueOf();
+  } 
+    
   // Get the body elements.
   var elements = gdc.getElements();
 

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -125,8 +125,11 @@ Render HTML tags
 <label>
 <input type="checkbox" id="suppress_info">
 Suppress top comment
-</label>
-
+</label><br>
+<label>
+<input type="checkbox" id="use_pre_code"> 
+Use &lt;code&gt;&lt;pre&gt; for HTML code blocks
+</label>	
 <!-- Docs, bug link. -->
 <br>
 <div style="text-align: left;"> 
@@ -175,6 +178,7 @@ For more details, click the Docs link above.`
     config.wrapHTML = false;
     config.renderHTMLTags = false;
     config.suppressInfo= false;
+	  config.useCodePre= false;
 
     // Config settings from UI.
     if (document.getElementById('demote_headings').checked) {
@@ -192,6 +196,9 @@ For more details, click the Docs link above.`
     if (document.getElementById('suppress_info').checked) {
       config.suppressInfo = true;
     }
+	 if (document.getElementById('use_pre_code').checked) {
+      config.usePreCode = true;
+    }  
 };
     
   // Make the calls to the server, and send some callbacks for


### PR DESCRIPTION
I know you rejected the enhancement request for this so its unlikely to make it in, but I thought I’d offer it anyway.

This adds an option to use &lt;code>&lt;pre> for code blocks, since the[ recommended way to mark up a code block](https://www.w3.org/TR/html5/grouping-content.html#the-pre-element) (both is a &lt;pre> element with a &lt;code> element inside, like so:

&lt;pre>&lt;code class="language-css">p { color: red }&lt;/code>&lt;/pre>

I also add a line numbers class in pre for utilities such as prism that respect this.  I’ve not made this optional but obviously could do.

I’ve tried to make the changes very minimal and obvious.

If you do want to incorporate the changes I can make the necessary mods to the docs as well.

I shared my copy of the verification document ([here](https://docs.google.com/document/d/1IFfbHWMdGHhfJJaOX4iyOPJ8A2TMFVJJvvNAkMrDkZQ/edit), but only you have access, not random passers-by)