### PR TITLE
Add bold and italic delimiter options

### DIFF
--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -118,6 +118,22 @@ gdc.config = function(config) {
   if (config.recklessMode === true) {
     gdc.recklessMode = true;
   }
+
+  if (config.mdBoldAsteriskDelimiters === true) {
+    gdc.mdMarkup.boldOpen = '**';
+    gdc.mdMarkup.boldClose = '**';
+  } else {
+    gdc.mdMarkup.boldOpen = '__';
+    gdc.mdMarkup.boldClose = '__';
+  }
+  
+  if (config.mdItalicAsteriskDelimiters === true) {
+    gdc.mdMarkup.italicOpen = '*';
+    gdc.mdMarkup.italicClose = '*';
+  } else {
+    gdc.mdMarkup.italicOpen = '_';
+    gdc.mdMarkup.italicClose = '_';
+  }
 };
 
 // Setup for each conversion run.

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -120,7 +120,8 @@ Wrap HTML
 <label>
 <input type="checkbox" id="render_html_tags">
 Render HTML tags
-</label><br>
+</label>
+<br>
 <label>
 <input type="checkbox" id="suppress_info">
 Suppress info comment
@@ -128,6 +129,32 @@ Suppress info comment
 <label>
 <input type="checkbox" id="reckless_mode">
 Use reckless mode (no alerts)
+</label>
+<br>
+<br>
+
+Markdown bold delimiters:<br>
+<label>
+<input type="radio" name="md_bold_delimiters" id="md_bold_asterisks" value="asterisks" checked>
+Asterisks (eg. **text**)
+</label>
+<br>
+<label>
+<input type="radio" name="md_bold_delimiters" id="md_bold_underscores" value="underscores">
+Underscores (eg. __text__)
+</label>
+<br>
+<br>
+
+Markdown italic delimiters:<br>
+<label>
+<input type="radio" name="md_italic_delimiters" id="md_italic_asterisks" value="asterisks">
+Asterisks (eg. *text*)
+</label>
+<br>
+<label>
+<input type="radio" name="md_italic_delimiters" id="md_italic_underscores" value="underscores" checked>
+Underscores (eg. _text_)
 </label>
 
 <!-- Docs, bug link. -->
@@ -179,6 +206,8 @@ For more details, click the Docs link above.`
     config.renderHTMLTags = false;
     config.suppressInfo = false;
     config.recklessMode = false;
+    config.mdBoldAsteriskDelimiters = false;
+    config.mdItalicAsteriskDelimiters = false;
 
     // Config settings from UI.
     if (document.getElementById('demote_headings').checked) {
@@ -198,6 +227,12 @@ For more details, click the Docs link above.`
     }
     if (document.getElementById('reckless_mode').checked) {
       config.recklessMode = true;
+    }
+    if (document.getElementById('md_bold_asterisks').checked) {
+      config.mdBoldAsteriskDelimiters = true;
+    }
+    if (document.getElementById('md_italic_asterisks').checked) {
+      config.mdItalicAsteriskDelimiters = true;
     }
 };
     


### PR DESCRIPTION
This PR implements #117, the option to encode italic in markdown as `*text*` instead of `_text_`, and the option to change the same for bold (`**text**` or `__text__`). The UI selectors for these are radio buttons, as shown below:

<img src=https://user-images.githubusercontent.com/55331709/211176501-e9eb990f-e2f4-4c9a-bbc9-35becd28c21a.png width="200">

The default settings follow the existing behaviour: asterisks for bold and underscores for italic.

Here is a link to my copy of the test document: https://docs.google.com/document/d/1buiYxin_Nmre3y_sXQbQGT8UFjsAgypWagoWik-YiQc/edit?usp=sharing

It takes several runs of the tool to check the possible option permutations this PR adds, and changing the options form the default will produce results differing from the markdown-verification.md standard output.

Note, however, that the addon code in this repo seems to be missing a few updates - it is still at v1.0B31 while the verification files indicate v1.0B34, so there are some discrepancies in the output because of this (these discrepancies are unrelated to this change). @evbacher Please update the addon code here on GitHub to the latest version (1.0B34).