### PR TITLE
Changed center/right alignment handling in handleHeading()

### DIFF
--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,7 +39,7 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β34'; // based on 1.0β33
+var GDC_VERSION = '1.0β36'; // based on 1.0β33
 
 // Version notes: significant changes (latest on top). (files changed)
 // - 1.0β36 (26 Sep. 2024): Moved the superscript/subscript open functions to be with the rest of the formatting functions. Moved maybeCloseAttrs() to the beginning of handleText() to ensure tags are closed before new tags are opened. (gdc)

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -778,7 +778,6 @@ gdc.handleText = function(textElement) {
     gdc.setWriteBuf();
     offset = gdc.writeBuf(textElement, offset, attrOff);
 
-
     // Check the attributes at the current attribute offset.
     // This should be an object.
     var url = textElement.getLinkUrl(attrOff),
@@ -798,19 +797,11 @@ gdc.handleText = function(textElement) {
     if (alignment === SUPERSCRIPT) {
       superscript = true;
     }
-    if (!gdc.isSubscript && subscript) {
-      gdc.useHtml();
-      gdc.isSubscript = true;
-      gdc.openAttrs.push(gdc.subscript);
-      gdc.writeStringToBuffer(gdc.markup.subOpen);
-    }
-    if (!gdc.isSuperscript && superscript) {
-      gdc.useHtml();
-      gdc.isSuperscript = true;
-      gdc.openAttrs.push(gdc.superscript);
-      gdc.writeStringToBuffer(gdc.markup.superOpen);
-    }
+
     var currentAttrs = gdc.getCurrentAttributes(textElement, attrOff);
+    // Try closing again before adding new current attribute?
+    // Attributes need to close for new text before opening any new attributes. This is for when words run together like italicsSUPERSCRIPT. or BOLDitalics 
+    gdc.maybeCloseAttrs(currentAttrs);
 
     // A philosophical question: should we define gdc.isItalic and friends up
     // top in gdc.gs, or just let them be defined here at first use? Might
@@ -852,6 +843,20 @@ gdc.handleText = function(textElement) {
       gdc.openAttrs.push(gdc.strikethrough);
       gdc.writeStringToBuffer(gdc.markup.strikethroughOpen);
     }
+    // Open subscript
+    if (!gdc.isSubscript && subscript) {
+      gdc.useHtml();
+      gdc.isSubscript = true;
+      gdc.openAttrs.push(gdc.subscript);
+      gdc.writeStringToBuffer(gdc.markup.subOpen);
+    }
+    // Open superscript
+    if (!gdc.isSuperscript && superscript) {
+      gdc.useHtml();
+      gdc.isSuperscript = true;
+      gdc.openAttrs.push(gdc.superscript);
+      gdc.writeStringToBuffer(gdc.markup.superOpen);
+    }
     // Open underline (uses HTML always). This should really be discouraged!
     if (!gdc.isUnderline && underline && !url) {
       gdc.isUnderline = true;
@@ -859,7 +864,8 @@ gdc.handleText = function(textElement) {
       gdc.writeStringToBuffer(gdc.markup.underlineOpen);
     }
 
-    gdc.maybeCloseAttrs(currentAttrs);
+    // Needs to run again to clear any formatting?
+    // gdc.maybeCloseAttrs(currentAttrs);
 
     // URL handling.
 

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -271,7 +271,6 @@ gdc.mixedMarkup = {
   underlineOpen: '<span style="text-decoration:underline;">',
   underlineClose: '</span>',
 
-
   // Paragraph, lists
   pOpen:        '<newline>',
   pClose:       '<newline>',
@@ -314,8 +313,6 @@ gdc.htmlMarkup = {
   strikethroughClose: '</del>',
   underlineOpen: '<span style="text-decoration:underline;">',
   underlineClose: '</span>',
-  centerOpen: '<center>',
-  centerClose: '</center>',
 
   pOpen:       '\n<p>\n',
   pClose:      '\n</p>',

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -316,7 +316,7 @@ gdc.htmlMarkup = {
 
   pOpen:       '\n<p>\n',
   pClose:      '\n</p>',
-  pBlank:      '\n<p>&nbsp</p>',
+  pBlank:      '\n<p>&nbsp;</p>',
   ulOpen:      '\n<ul>',
   ulClose:     '\n</ul>',
   olOpen:      '\n<ol>',

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -42,6 +42,7 @@ var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
 var GDC_VERSION = '1.0β34'; // based on 1.0β33
 
 // Version notes: significant changes (latest on top). (files changed)
+// - 1.0β35 (25 Sep. 2024): Add target blank option. Add blank lines to HTML). (sidebar, gdc, html)
 // - 1.0β34 (12 Dec. 2022): Clarify note about TOC -- needs blue links to create intra-doc links). (gdc)
 // - 1.0β33 (8 Jan. 2022): Add reckless mode (no warnings or inline alerts). (sidebar, gdc, html)
 // - 1.0β32 (7 Jan. 2022): Make the Donate button more obvious. (gdc, sidebar)
@@ -117,6 +118,9 @@ gdc.config = function(config) {
   }
   if (config.recklessMode === true) {
     gdc.recklessMode = true;
+  }
+  if (config.targetBlank === true) {
+    gdc.targetBlank = true;
   }
 };
 
@@ -312,6 +316,7 @@ gdc.htmlMarkup = {
 
   pOpen:       '\n<p>\n',
   pClose:      '\n</p>',
+  pBlank:      '\n<p>&nbsp</p>',
   ulOpen:      '\n<ul>',
   ulClose:     '\n</ul>',
   olOpen:      '\n<ol>',
@@ -319,6 +324,7 @@ gdc.htmlMarkup = {
   ulItem:      '\n<li>',
   olItem:      '\n<li>',
   liClose:     '\n</li>',
+  
 
   hr:           '\n<hr>',
 
@@ -884,8 +890,13 @@ gdc.handleText = function(textElement) {
           gdc.setWriteBuf();
           offset = gdc.writeBuf(textElement, offset, urlEnd);
           gdc.writeStringToBuffer('](' + url + ')');
-      } else {  // Must be HTML, write standard link.
+      } else if (gdc.isHTML && !gdc.targetBlank ) {  // If we aren't adding target="_blank".
         gdc.writeStringToBuffer('<a href="' + url + '">');
+        gdc.setWriteBuf();
+        offset = gdc.writeBuf(textElement, offset, urlEnd);
+        gdc.writeStringToBuffer('</a>');
+      }  else if (gdc.isHTML && gdc.targetBlank ) {  // If target blank is selected
+        gdc.writeStringToBuffer('<a target="_blank" href="' + url + '">');
         gdc.setWriteBuf();
         offset = gdc.writeBuf(textElement, offset, urlEnd);
         gdc.writeStringToBuffer('</a>');
@@ -1295,6 +1306,8 @@ gdc.maybeCloseAttrs = function(currentAttrs) {
 // At the end of a paragraph or list item, we want to close all open attributes.
 // This is similar to maybeCloseAttrs, but we want to close all of them in
 // the openAttrs list (and we do not have an explicit attribute change here).
+
+// Needs to close when the attribute stops. Not at paragraph/word end. 
 gdc.closeAllAttrs = function() {
   while (gdc.openAttrs.length > 0) {
     var a = gdc.openAttrs.pop();
@@ -1773,7 +1786,7 @@ md.handleParagraph = function(para) {
   gdc.inHeading = false;
   gdc.state.isMixedCode = false;
   gdc.numChildren = para.getNumChildren();
-  // Do not bother with empty paragraphs (blank lines). (Except we preserve them for code blocks.)
+  // Preserve blank lines in body text as well as code blocks
   if (gdc.numChildren === 0) {
     if (gdc.inCodeBlock) {
       // Preserve newlines in code block (or single-cell table code block).
@@ -1781,6 +1794,9 @@ md.handleParagraph = function(para) {
         // Write a placeholder for newline: will replace after wrapping.
         gdc.writeStringToBuffer('<newline>');
       }
+    } else if (gdc.docType === gdc.docTypes.html) {
+      // Add blank lines in HTML by default
+      gdc.writeStringToBuffer(gdc.htmlMarkup.pBlank);
     }
     return;
   }

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,10 +39,10 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β35'; // based on 1.0β33
+var GDC_VERSION = '1.0β34'; // based on 1.0β33
 
 // Version notes: significant changes (latest on top). (files changed)
-// - 1.0β35 (25 Sep. 2024): Add target blank option. Add blank lines to HTML). (sidebar, gdc, html)
+// - 1.0β35 (25 Sep. 2024): Add target blank option. Add blank lines to HTML. Added center-alignment for HTML. (sidebar, gdc, html)
 // - 1.0β34 (12 Dec. 2022): Clarify note about TOC -- needs blue links to create intra-doc links). (gdc)
 // - 1.0β33 (8 Jan. 2022): Add reckless mode (no warnings or inline alerts). (sidebar, gdc, html)
 // - 1.0β32 (7 Jan. 2022): Make the Donate button more obvious. (gdc, sidebar)
@@ -271,6 +271,7 @@ gdc.mixedMarkup = {
   underlineOpen: '<span style="text-decoration:underline;">',
   underlineClose: '</span>',
 
+
   // Paragraph, lists
   pOpen:        '<newline>',
   pClose:       '<newline>',
@@ -313,6 +314,8 @@ gdc.htmlMarkup = {
   strikethroughClose: '</del>',
   underlineOpen: '<span style="text-decoration:underline;">',
   underlineClose: '</span>',
+  centerOpen: '<center>',
+  centerClose: '</center>',
 
   pOpen:       '\n<p>\n',
   pClose:      '\n</p>',
@@ -353,12 +356,14 @@ gdc.strikethrough = 's';
 gdc.underline = 'u';
 gdc.subscript = 'sub';
 gdc.superscript = 'sup';
+gdc.centered = 'center';
 
 // Constants for text alignment types.
 var
   NORMAL = DocumentApp.TextAlignment.NORMAL,
   SUBSCRIPT = DocumentApp.TextAlignment.SUBSCRIPT,
   SUPERSCRIPT = DocumentApp.TextAlignment.SUPERSCRIPT;
+  CENTERED = DocumentApp.HorizontalAlignment.CENTER;
 
 // Constants for the various element types. This is really for convenience.
 // These are types contained in BODY. See the enum DocumentApp.ElementType.
@@ -1891,6 +1896,13 @@ md.handleParagraph = function(para) {
   // Check horizontal alignment. We can style right alignment using an HTML paragraph.
   if (para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
     gdc.writeStringToBuffer('<p style="text-align: right">\n');
+    gdc.useHtml();
+    gdc.isRightAligned = true;
+  }
+
+  // Check horizontal alignment. We can style center alignment using an HTML paragraph.
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.CENTER && para.isLeftToRight()) {
+    gdc.writeStringToBuffer('<p style="text-align: center">\n');
     gdc.useHtml();
     gdc.isRightAligned = true;
   }

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,7 +39,7 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β34'; // based on 1.0β33
+var GDC_VERSION = '1.0β35'; // based on 1.0β33
 
 // Version notes: significant changes (latest on top). (files changed)
 // - 1.0β35 (25 Sep. 2024): Add target blank option. Add blank lines to HTML). (sidebar, gdc, html)

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -42,6 +42,7 @@ var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
 var GDC_VERSION = '1.0β34'; // based on 1.0β33
 
 // Version notes: significant changes (latest on top). (files changed)
+// - 1.0β36 (26 Sep. 2024): Moved the superscript/subscript open functions to be with the rest of the formatting functions. Moved maybeCloseAttrs() to the beginning of handleText() to ensure tags are closed before new tags are opened. (gdc)
 // - 1.0β35 (25 Sep. 2024): Add target blank option. Add blank lines to HTML. Added center-alignment for HTML. (sidebar, gdc, html)
 // - 1.0β34 (12 Dec. 2022): Clarify note about TOC -- needs blue links to create intra-doc links). (gdc)
 // - 1.0β33 (8 Jan. 2022): Add reckless mode (no warnings or inline alerts). (sidebar, gdc, html)
@@ -799,7 +800,6 @@ gdc.handleText = function(textElement) {
     }
 
     var currentAttrs = gdc.getCurrentAttributes(textElement, attrOff);
-    // Try closing again before adding new current attribute?
     // Attributes need to close for new text before opening any new attributes. This is for when words run together like italicsSUPERSCRIPT. or BOLDitalics 
     gdc.maybeCloseAttrs(currentAttrs);
 

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -1923,16 +1923,6 @@ md.handleParagraph = function(para) {
   // In case we're in a mixed code span, reset the markup.
   gdc.resetMarkup();
 
-  // if (gdc.isRightAligned) {
-  //   gdc.writeStringToBuffer('\n</p>');
-  //   gdc.isRightAligned = false;
-  // }
-
-  //if (gdc.isCentered) {
-  //  gdc.writeStringToBuffer('\n</center>');
-  //  gdc.isCentered = false;
-  //}
-
   // Now that we're at the end, close heading or paragraph if necessary.
   if (gdc.docType === gdc.docTypes.md && gdc.inHeading && !gdc.isHTML) {
     // Trim heading text to use as hash key (we trim it in gdc.makeId() ).
@@ -1964,7 +1954,6 @@ md.handleParagraph = function(para) {
     }
   }
   
-  //gdc.maybeCloseList(para);
 }; // end md.handleParagraph
 
 // Handle the heading type of the paragraph. Fall through for NORMAL.

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -413,6 +413,16 @@ html.handleHeading = function(heading, para) {
     gdc.writeStringToBuffer(' id="' + gdc.headingIds[para.getText()] + '"');
   }
   
+  // Check for right alignment before closing the tag
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
+    gdc.writeStringToBuffer(' style="text-align: right"');
+  }
+
+  // Check for center alignment before closing the tag
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.CENTER && para.isLeftToRight()) {
+    gdc.writeStringToBuffer(' style="text-align: center"');
+  }
+
   // Close the tag.
   gdc.writeStringToBuffer('>');
 };

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -131,7 +131,7 @@ Use reckless mode (no alerts)
 </label><br>
 <label>
 <input type="checkbox" id="target_blank">
-Add target_blank to HTML links
+Add target="_blank" to HTML links
 </label>
 
 <!-- Docs, bug link. -->

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -128,6 +128,10 @@ Suppress info comment
 <label>
 <input type="checkbox" id="reckless_mode">
 Use reckless mode (no alerts)
+</label><br>
+<label>
+<input type="checkbox" id="target_blank">
+Add target_blank to HTML links
 </label>
 
 <!-- Docs, bug link. -->
@@ -179,6 +183,7 @@ For more details, click the Docs link above.`
     config.renderHTMLTags = false;
     config.suppressInfo = false;
     config.recklessMode = false;
+    config.targetBlank = false;
 
     // Config settings from UI.
     if (document.getElementById('demote_headings').checked) {
@@ -198,6 +203,9 @@ For more details, click the Docs link above.`
     }
     if (document.getElementById('reckless_mode').checked) {
       config.recklessMode = true;
+    }
+    if (document.getElementById('target_blank').checked) {
+      config.targetBlank = true;
     }
 };
     


### PR DESCRIPTION
Sorry to add an update right after you updated, but I realized the center/right alignment wasn't working properly. It was always adding a new <p> tag which messed up the headings. 

I changed how center/right alignment were handled in the gdc and HTML. I needed to check for center/right alignment within the <h*> tag or before writing a \<p> tag so that these styles could be properly added to the tag itself. 

New changes are on lines: 1877-1889 in gdc.gs and 416-425 in html.gs

Thanks. 