### PR TITLE
Center/right alignment fix

### DIFF
--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -1850,8 +1850,19 @@ md.handleParagraph = function(para) {
       // do nothing: we also want to not add the tablePrefix.
       // But check for table cell or definition list.
     } else if (!gdc.startingTableCell && !gdc.inDlist) {
-      gdc.writeStringToBuffer(gdc.markup.pOpen);
+      // This is where we want to check for right/center alignment so that the proper paragraph style can be applied. 
+      if (gdc.isHTML && para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
+        gdc.writeStringToBuffer('\n<p style="text-align: right">\n');
+        // Not sure what this does?
+        gdc.useHtml();
+      } else if (gdc.isHTML && para.getAlignment() === DocumentApp.HorizontalAlignment.CENTER && para.isLeftToRight()) {
+        gdc.writeStringToBuffer('\n<p style="text-align: center">\n');
+        gdc.useHtml();
+      } else {
+        gdc.writeStringToBuffer(gdc.markup.pOpen);
+      }
     }
+
     // We want paragraphs after the first text in a table cell.
     gdc.startingTableCell = false;
   }

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,9 +39,10 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β34'; // based on 1.0β33
+var GDC_VERSION = '1.0β35'; // based on 1.0β33
 
 // Version notes: significant changes (latest on top). (files changed)
+// - 1.0β35 (6 Oct. 2024): Added center-alignment for HTML. Changed how center/right alignment are handled. Placed inside html.handleHeading  (sidebar, gdc, html)
 // - 1.0β34 (12 Dec. 2022): Clarify note about TOC -- needs blue links to create intra-doc links). (gdc)
 // - 1.0β33 (8 Jan. 2022): Add reckless mode (no warnings or inline alerts). (sidebar, gdc, html)
 // - 1.0β32 (7 Jan. 2022): Make the Donate button more obvious. (gdc, sidebar)

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -1883,13 +1883,6 @@ md.handleParagraph = function(para) {
     }
   }
 
-  // Check horizontal alignment. We can style right alignment using an HTML paragraph.
-  if (para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
-    gdc.writeStringToBuffer('<p style="text-align: right">\n');
-    gdc.useHtml();
-    gdc.isRightAligned = true;
-  }
-
   // Detects text direction.
   if (!para.isLeftToRight()) {
     gdc.writeStringToBuffer('<p dir="rtl">\n');

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -412,6 +412,16 @@ html.handleHeading = function(heading, para) {
   if (id) {
     gdc.writeStringToBuffer(' id="' + gdc.headingIds[para.getText()] + '"');
   }
+
+  // Check for right alignment before closing the tag
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
+    gdc.writeStringToBuffer(' style="text-align: right"');
+  }
+
+  // Check for center alignment before closing the tag
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.CENTER && para.isLeftToRight()) {
+    gdc.writeStringToBuffer(' style="text-align: center"');
+  }
   
   // Close the tag.
   gdc.writeStringToBuffer('>');


### PR DESCRIPTION
This isolates the handling of the center/right alignment for HTML. 

It moves where it is handled for paragraphs and adds some handling for headings. 

This should be identical to the previous pull requests, but isolates this one feature to more easily review. 