### PR TITLE
1.0β39: fix internal links break due to Google Docs' new tabbed interface.

### DIFF
--- a/addon/addon.gs
+++ b/addon/addon.gs
@@ -1,3 +1,5 @@
+// *** addon.gs ***
+
 /*
  * Copyright 2020 Google LLC
  *

--- a/addon/appsscript.json
+++ b/addon/appsscript.json
@@ -1,6 +1,10 @@
 {
   "timeZone": "America/Los_Angeles",
   "dependencies": {},
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/documents.currentonly",
+    "https://www.googleapis.com/auth/script.container.ui"
+  ],
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "DEPRECATED_ES5"
 }

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -1,3 +1,5 @@
+// *** html.gs ***
+
 /*
  * Copyright 2020 Google LLC
  *
@@ -105,6 +107,10 @@ html.doHtml = function(config) {
     // But notify if there are errors.
     gdc.out = '<!-- ' + gdc.errorSummary + ' -->\n' + gdc.out;
   }
+
+  // Always include the banner.
+  gdc.out = gdc.banner + gdc.out;
+
   
   // Output content.
   gdc.flushBuffer();

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -1,3 +1,5 @@
+<!-- sidebar.html -->
+
 <!--
 Copyright 2020 Google LLC
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<!-- sidebar.html -->
 <!-- See this stylesheet for the class names we're using. -->
 <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons.css">
 


### PR DESCRIPTION
// - 1.0β39 (12 October 2024): Google Docs recently added a tab interface, which changes the TOC-generated id. This breaks internal links. This release fixes that bug. (gdc, html)
