### PR TITLE
Dev main 1.0β38 base  --> main, version: 1.0β40: 13 Oct 2024

### DIFF
--- a/addon/appsscript.json
+++ b/addon/appsscript.json
@@ -1,6 +1,11 @@
 {
   "timeZone": "America/Los_Angeles",
-  "dependencies": {},
+  "dependencies": {
+  },
   "exceptionLogging": "STACKDRIVER",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/documents.currentonly", 
+    "https://www.googleapis.com/auth/script.container.ui"
+    ],
   "runtimeVersion": "DEPRECATED_ES5"
 }

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,11 +39,10 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β43'; // based on 1.0β42
+var GDC_VERSION = '1.0β42'; // based on 1.0β41
 
 // Version notes: significant changes (latest on top). (files changed)
-// - 1.0β43 (8 Oct 2024): Close list items before opening a new item. Close at the end of the list. (gdc, html)
-// - 1.0β42 (7 Oct 2024): Add option for adding target="_blank" to links (gdc, sidebar)
+// - 1.0β42 (8 Oct 2024): Close list items before opening a new item. Close at the end of the list. (gdc, html)
 // - 1.0β41 (7 Oct 2024): Add support for Markdown checkbox lists. (gdc)
 // - 1.0β40 (7 Oct 2024): Fixes handling of superscript/subscript to close old styles before opening new style. Moves opening superscript/subscript later in process. (gdc)
 // - 1.0β39 (7 Oct 2024): Added center/right alignment to HTML paragraph and heading handling. Will add text-align: center/right depending on paragraph formatting. (html, gdc)
@@ -132,9 +131,6 @@ gdc.config = function(config) {
   }
   if (config.suppressInfo === true) {
     gdc.suppressInfo = true;
-  }
-  if (config.targetBlank === true) {
-    gdc.targetBlank = true;
   }
   if (config.recklessMode === true) {
     gdc.recklessMode = true;
@@ -918,13 +914,8 @@ gdc.handleText = function(textElement) {
           gdc.setWriteBuf();
           offset = gdc.writeBuf(textElement, offset, urlEnd);
           gdc.writeStringToBuffer('](' + url + ')');
-      } else if (gdc.isHTML && !gdc.targetBlank ) {  // If we aren't adding target="_blank".
+      } else {  // Must be HTML, write standard link.        
         gdc.writeStringToBuffer('<a href="' + url + '">');
-        gdc.setWriteBuf();
-        offset = gdc.writeBuf(textElement, offset, urlEnd);
-        gdc.writeStringToBuffer('</a>');
-      }  else if (gdc.isHTML && gdc.targetBlank ) {  // If target blank is selected
-        gdc.writeStringToBuffer('<a target="_blank" href="' + url + '">');
         gdc.setWriteBuf();
         offset = gdc.writeBuf(textElement, offset, urlEnd);
         gdc.writeStringToBuffer('</a>');

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -52,10 +52,10 @@ gdc.banner = '<!-- NOTICE: Google recently added tabs to Google Docs: '
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β42'; // based on 1.0β41
+var GDC_VERSION = '1.0β40'; // based on 1.0β39'
 
 // Version notes: significant changes (latest on top). (files changed)
-/** - 1.0β40 (12 Oct 2024): 
+/** - 1.0β40 (13 Oct 2024): 
     - Close list items before opening a new item. Close at the end of the list. (gdc, html)
     - Add support for Markdown checkbox lists. (gdc)
     - Fixes handling of superscript/subscript to close old styles before opening new style. Moves opening superscript/subscript later in process. (gdc)
@@ -76,14 +76,14 @@ var GDC_VERSION = '1.0β42'; // based on 1.0β41
 // - 1.0β32 (7 Jan. 2022): Make the Donate button more obvious. (gdc, sidebar)
 // - 1.0β31 (24 Aug. 2021): Don't contain <hr> in <p> for HTML. (gdc)
 // - 1.0β30 (1 July 2021): Reduce whitespace after list item (bullets, numbers) in Markdown. (gdc)
-// - 1.0β29: Handle partial selections correctly (expand to whole paragraph). (gdc)
-// - 1.0β28: Add Coffee button. UI change only. (gdc, sidebar)
-// - 1.0β27: Copy output to clipboard. Print success/error messages for clipboard output (see chromium bug 1074489). (gdc, sidebar)
-// - 1.0β26: Render soft line breaks correctly in HTML (<br> not &lt;br>). (gdc)
-// - 1.0β25: Use image path in this form: images/image1.png, images/image2.png, etc. Clean up old zip image code. (gdc,html,sidebar)
+// - 1.0β29 (2 Jul. 2020): Handle partial selections correctly (expand to whole paragraph). (gdc)
+// - 1.0β28 (2 Jul. 2020): Add Coffee button. UI change only. (gdc, sidebar)
+// - 1.0β27 (19 June 2020): Copy output to clipboard. Print success/error messages for clipboard output (see chromium bug 1074489). (gdc, sidebar)
+// - 1.0β26 (6 June 2020): Render soft line breaks correctly in HTML (<br> not &lt;br>). (gdc)
+// - 1.0β25 (1 June 2020): Use image path in this form: images/image1.png, images/image2.png, etc. Clean up old zip image code. (gdc,html,sidebar)
 // - 1.0β24: Correct a spelling error (s/Supress/Suppress). (gdc)
-// - 1.0β23: Copy converted output to the clipboard. Add option to suppress top comment. Add copyright comment, note about Docs link. (gdc, html, sidebar, addon)
-// - 1.0β22: Roll back font-change runs for now (still causing problems), but keep table note. (gdc)
+// - 1.0β23 (3 May 2020): Copy converted output to the clipboard. Add option to suppress top comment. Add copyright comment, note about Docs link. (gdc, html, sidebar, addon)
+// - 1.0β22 (21 April 2020: first open-source version): Roll back font-change runs for now (still causing problems), but keep table note. (gdc)
 // - 1.0β21: Add a note that tables are currently converted to HTML tables. No change to rendered conversion. (gdc, html)
 // - 1.0β20: Handle font-change runs with extra whitespace better (italic, bold, etc.). (gdc)
 // - 1.0β19: Fix for angle bracket at beginning of a line. Also: use doc title instead of URL in conversion comment. (gdc)
@@ -825,7 +825,7 @@ gdc.handleText = function(textElement) {
     if (alignment === SUPERSCRIPT) {
       superscript = true;
     }
-   
+
     var currentAttrs = gdc.getCurrentAttributes(textElement, attrOff);
     // Attributes need to close for new text before opening any new attributes. This is for when words run together like italicsSUPERSCRIPT. or BOLDitalics 
     gdc.maybeCloseAttrs(currentAttrs);
@@ -887,6 +887,7 @@ gdc.handleText = function(textElement) {
       gdc.openAttrs.push(gdc.superscript);
       gdc.writeStringToBuffer(gdc.markup.superOpen);
     }
+
     // Open underline (uses HTML always). This should really be discouraged!
     if (!gdc.isUnderline && underline && !url) {
       gdc.isUnderline = true;
@@ -1348,7 +1349,14 @@ gdc.maybeCloseAttrs = function(currentAttrs) {
       gdc.openAttrs.pop();
       keepChecking = true;
       if (!gdc.inCodeBlock) {
+        // Check to see if we're in a mixed font span (mixed code with other font styles).
+        // If so, use HTML (or mixed)
+        if (gdc.isMixedCode) {
+          gdc.useMixed();
+        }
         gdc.writeStringToBuffer(gdc.markup.codeClose);
+        // We probably don't want to continue using mixed markup.
+        gdc.resetMarkup
       }
     }
     // Close bold.

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,8 +39,10 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β41'; // based on 1.0β40
+var GDC_VERSION = '1.0β42'; // based on 1.0β41
 
+// Version notes: significant changes (latest on top). (files changed)
+// - 1.0β42 (7 Oct 2024): Add option for adding target="_blank" to links (gdc, sidebar)
 // Version notes: significant changes (latest on top). (files changed)
 // - 1.0β41 (7 Oct 2024): Add support for Markdown checkbox lists. (gdc)
 // - 1.0β40 (7 Oct 2024): Fixes handling of superscript/subscript to close old styles before opening new style. Moves opening superscript/subscript later in process. (gdc)
@@ -130,6 +132,9 @@ gdc.config = function(config) {
   }
   if (config.suppressInfo === true) {
     gdc.suppressInfo = true;
+  }
+  if (config.targetBlank === true) {
+    gdc.targetBlank = true;
   }
   if (config.recklessMode === true) {
     gdc.recklessMode = true;
@@ -913,8 +918,13 @@ gdc.handleText = function(textElement) {
           gdc.setWriteBuf();
           offset = gdc.writeBuf(textElement, offset, urlEnd);
           gdc.writeStringToBuffer('](' + url + ')');
-      } else {  // Must be HTML, write standard link.
+      } else if (gdc.isHTML && !gdc.targetBlank ) {  // If we aren't adding target="_blank".
         gdc.writeStringToBuffer('<a href="' + url + '">');
+        gdc.setWriteBuf();
+        offset = gdc.writeBuf(textElement, offset, urlEnd);
+        gdc.writeStringToBuffer('</a>');
+      }  else if (gdc.isHTML && gdc.targetBlank ) {  // If target blank is selected
+        gdc.writeStringToBuffer('<a target="_blank" href="' + url + '">');
         gdc.setWriteBuf();
         offset = gdc.writeBuf(textElement, offset, urlEnd);
         gdc.writeStringToBuffer('</a>');
@@ -1010,6 +1020,7 @@ gdc.isBullet = function(glyphType) {
       return 'bullet';
   } else if (glyphType === null) {
     // Since checkboxes currently return null and we know it is a list, this should work to find a checkbox item until Google adds another
+    // See https://developers.google.com/apps-script/reference/document/glyph-type for glyph enum if this breaks.
     return 'checkbox';
   // Spelling out ordered list glyphs rather than relying on "everything but null"
   // } else if (  glyphType === DocumentApp.GlyphType.NUMBER

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -39,9 +39,10 @@
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β40'; // based on 1.0β39
+var GDC_VERSION = '1.0β41'; // based on 1.0β40
 
-// Version notes: significant changes (latest on top). (files changed)\
+// Version notes: significant changes (latest on top). (files changed)
+// - 1.0β41 (7 Oct 2024): Add support for Markdown checkbox lists. (gdc)
 // - 1.0β40 (7 Oct 2024): Fixes handling of superscript/subscript to close old styles before opening new style. Moves opening superscript/subscript later in process. (gdc)
 // - 1.0β39 (7 Oct 2024): Added center/right alignment to HTML paragraph and heading handling. Will add text-align: center/right depending on paragraph formatting. (html, gdc)
 // - 1.0β38 (21 Sept 2024): Italic/bold markup default is now */**: _/__ is now an option. Reckless mode now includes Suppress info comment (removed sidebar option too). Also add a News link to gd2md-html news page in sidebar. (sidebar, gdc)
@@ -251,6 +252,7 @@ gdc.mdMarkup = {
   olClose:      '<newline>',
   ulItem:       '* ',
   olItem:       '1. ',
+  cboxItem:     '- [ ] ',
   liClose:      '',
 
   hr:           '<newline><newline>---<newline>',
@@ -294,6 +296,7 @@ gdc.mixedMarkup = {
   olClose:      '',
   ulItem:       '* ',
   olItem:       '1. ',
+  cboxItem:     '- [ ] ',
   liClose:      '',
 
   hr:           '<newline><newline>---<newline>',
@@ -1004,9 +1007,18 @@ gdc.isBullet = function(glyphType) {
   if (   glyphType === DocumentApp.GlyphType.BULLET
       || glyphType === DocumentApp.GlyphType.HOLLOW_BULLET
       || glyphType === DocumentApp.GlyphType.SQUARE_BULLET) {
-      return true;
-  } else {
-    return false;
+      return 'bullet';
+  } else if (glyphType === null) {
+    // Since checkboxes currently return null and we know it is a list, this should work to find a checkbox item until Google adds another
+    return 'checkbox';
+  // Spelling out ordered list glyphs rather than relying on "everything but null"
+  // } else if (  glyphType === DocumentApp.GlyphType.NUMBER
+  //           || glyphType === DocumentApp.GlyphType.LATIN_UPPER 
+  //           || glyphType === DocumentApp.GlyphType.LATIN_LOWER
+  //           || glyphType === DocumentApp.GlyphType.ROMAN_UPPER 
+  //           || glyphType === DocumentApp.GlyphType.ROMAN_LOWER) { 
+  } else { 
+    return 'ordered list';
   }
 };
 
@@ -1891,8 +1903,8 @@ md.handleParagraph = function(para) {
       if (gdc.isHTML && para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
         gdc.writeStringToBuffer('\n<p style="text-align: right">\n');
         // Not sure what this does?
-        gdc.useHtml();
-        gdc.isRightAligned = true;
+        gdc.useHtml(); // TODO: check this!
+        //gdc.isRightAligned = true; // TODO: check this!
       } else if (gdc.isHTML && para.getAlignment() === DocumentApp.HorizontalAlignment.CENTER && para.isLeftToRight()) {
         gdc.writeStringToBuffer('\n<p style="text-align: center">\n');
         gdc.useHtml();
@@ -2062,9 +2074,9 @@ md.handleListItem = function(listItem) {
     prefix += '<listindent>';
   }
   // Check for bullet list.
-  if (gdc.isBullet(glyphType)) {
+  if (gdc.isBullet(glyphType) === 'bullet') {
     prefix += gdc.markup.ulItem;
-  } else {
+  } else if (gdc.isBullet(glyphType) === 'ordered list') {
     // Ordered list.
     var key = listItem.getListId() + '.' + nestLevel;
     // Initialize list counter.
@@ -2074,8 +2086,11 @@ md.handleListItem = function(listItem) {
     // Increment ordered list counter.
     prefix += counter + '. ';
     // Alternative is to use 1. for all ordered list items, but less readable.
-    //prefix += gdc.markup.olItem;
+    // prefix += gdc.markup.olItem;
+  } else if (gdc.isBullet(glyphType) === 'checkbox') { // Maybe it's unecessary to spell out and just leave as an "else" statement.
+    prefix += gdc.markup.cboxItem
   }
+
   gdc.writeStringToBuffer(prefix);
 
   // Prefix set, now deal with the content.

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -36,7 +36,14 @@ var html = html || {
 
   // non-semantic underline, since Docs supports it.
   underlineStart: '<span style="text-decoration:underline;">',
-  underlineEnd:   '</span>'
+  underlineEnd:   '</span>',
+
+
+  // I think we need to track these independently because the previous/next sibling won't always be a list item, 
+  // thus not giving reliable nesting level. 
+  listNestingLevel: 0,
+  // This will also help us know if a list item needs to be closed before opening a new one. 
+  inListItem: false
 };
 
 html.tablePrefix = '  ';
@@ -499,12 +506,10 @@ html.handleListItem = function(listItem) {
 
   html.nestingLevel = listItem.getNestingLevel();
 
-  // Check if we're in a code block and end if so.
-  if (gdc.inCodeBlock) {
-    gdc.writeStringToBuffer(html.closeCodeBlock);
-    gdc.inCodeBlock = false;
+  // Check if a list item is already open, and if so, close it. We will always want to close a listItem before opening a new one.
+  if (html.inListItem) {
+    html.closeListItem();
   }
-
 
   gdc.listPrefix = '';
   for (var i = 0; i < html.nestingLevel; i++) {
@@ -525,6 +530,7 @@ html.handleListItem = function(listItem) {
   gdc.writeStringToBuffer('\n');
   // Note that ulItem, olItem are the same in HTML (<li>).
   gdc.writeStringToBuffer(gdc.listPrefix + gdc.htmlMarkup.ulItem);
+  html.inListItem = true;
   md.childLoop(listItem);
   
   // Check to see if we should close this list.
@@ -541,7 +547,14 @@ html.checkList = function() {
 };
 // Closes list item. Not necessary for Markdown.
 html.closeListItem = function() {
+  // Check if we're in a code block and end if so. Always close codeblocks before closing list items. 
+  if (gdc.inCodeBlock) {
+    gdc.writeStringToBuffer(html.closeCodeBlock);
+    gdc.inCodeBlock = false;
+  }
+
   gdc.writeStringToBuffer(gdc.markup.liClose);
+  html.inListItem = false;
 };
 html.maybeOpenList = function (listItem) {
   // Do we need to open a list?
@@ -552,13 +565,23 @@ html.maybeOpenList = function (listItem) {
   }
   // Open list if last sibling was not a list item.
   if (previousType !== DocumentApp.ElementType.LIST_ITEM) {
-    html.openList();
-  } else
+    // We need to check if a list is already opened first. Is a global variable to track list level the best solution here? 
+    // The previous sibling won't return the list level if it's a paragraph. 
+
+    // Could we also use:
+    // if (html.nestingLevel == 0 && gdc.isList == false) {
+
+    if (html.nestingLevel >= html.listNestingLevel) {
+      html.openList();
+    } 
+  } else if (previousType == DocumentApp.ElementType.LIST_ITEM) {
     // Open a new list if nesting level increases.
-    if (html.nestingLevel > previous.getNestingLevel()) {
-    html.openList();
+      if (html.nestingLevel > previous.getNestingLevel()) {
+      html.openList();
+      }
   }
 };
+
 // Open list and save current list type to stack.
 html.openList = function() {
   gdc.isList = true;
@@ -575,22 +598,28 @@ html.openList = function() {
     gdc.writeStringToBuffer(gdc.listPrefix + gdc.htmlMarkup.olOpen);
     html.listStack.unshift(gdc.ol);
   }
+  html.listNestingLevel++;
 };
+
 // Close list and remove it's list type from the stack.
 html.closeList = function() {
-  // Close the last item of the list.
+  // Close the last item of the list. This will always need to be called.
   html.closeListItem();
+
   if (html.listStack[0] === gdc.ul) {
     gdc.writeStringToBuffer(gdc.listPrefix + gdc.htmlMarkup.ulClose);
+    html.listNestingLevel--;
   }
   if (html.listStack[0] === gdc.ol) {
     gdc.writeStringToBuffer(gdc.listPrefix + gdc.htmlMarkup.olClose);
+    html.listNestingLevel--;
   }
   html.listStack.shift();
   if (html.listStack.length === 0) {
     gdc.isList = false;
   }
 };
+
 // But what about a table that's in a list item?
 html.closeAllLists = function() {
   var list = html.listStack[0];

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -412,7 +412,17 @@ html.handleHeading = function(heading, para) {
   if (id) {
     gdc.writeStringToBuffer(' id="' + gdc.headingIds[para.getText()] + '"');
   }
-  
+
+  // Check for right alignment before closing the tag
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {
+    gdc.writeStringToBuffer(' style="text-align: right"');
+  }
+
+  // Check for center alignment before closing the tag
+  if (para.getAlignment() === DocumentApp.HorizontalAlignment.CENTER && para.isLeftToRight()) {
+    gdc.writeStringToBuffer(' style="text-align: center"');
+  }
+
   // Close the tag.
   gdc.writeStringToBuffer('>');
 };

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -126,8 +126,12 @@ Wrap HTML
 Render HTML tags
 </label><br>
 <label>
+<input type="checkbox" id="target_blank">
+Add target="_blank" to HTML links
+</label><br>
 
 <!-- Collapsing suppress_info and reckless_mode for now.
+<label>
 <input type="checkbox" id="suppress_info">
 Suppress info comments
 </label><br>
@@ -192,6 +196,7 @@ If you have questions for the Docs to Markdown community, use the Questions link
     config.renderHTMLTags = false;
     config.suppressInfo = false;
     config.recklessMode = false;
+    config.targetBlank = false;
 
     // Config settings from UI.
     if (document.getElementById('italic_bold_underscores').checked) {
@@ -205,6 +210,9 @@ If you have questions for the Docs to Markdown community, use the Questions link
     }
     if (document.getElementById('wrap_html').checked) {
       config.wrapHTML = true;
+    }
+    if (document.getElementById('target_blank').checked) {
+      config.targetBlank = true;
     }
     if (document.getElementById('render_html_tags').checked) {
       config.renderHTMLTags = true;

--- a/addon/sidebar.html
+++ b/addon/sidebar.html
@@ -124,11 +124,8 @@ Wrap HTML
 <label>
 <input type="checkbox" id="render_html_tags">
 Render HTML tags
-</label><br>
-<label>
-<input type="checkbox" id="target_blank">
-Add target="_blank" to HTML links
-</label><br>
+</label>
+<br>
 
 <!-- Collapsing suppress_info and reckless_mode for now.
 <label>
@@ -196,7 +193,6 @@ If you have questions for the Docs to Markdown community, use the Questions link
     config.renderHTMLTags = false;
     config.suppressInfo = false;
     config.recklessMode = false;
-    config.targetBlank = false;
 
     // Config settings from UI.
     if (document.getElementById('italic_bold_underscores').checked) {
@@ -210,9 +206,6 @@ If you have questions for the Docs to Markdown community, use the Questions link
     }
     if (document.getElementById('wrap_html').checked) {
       config.wrapHTML = true;
-    }
-    if (document.getElementById('target_blank').checked) {
-      config.targetBlank = true;
     }
     if (document.getElementById('render_html_tags').checked) {
       config.renderHTMLTags = true;


### PR DESCRIPTION
version: 1.0β40: 13 Oct 2024: includes pull requests from @sevenshamrocks fixing these issues/new features.

```
/** - 1.0β40 (13 Oct 2024): 
    - Close list items before opening a new item. Close at the end of the list. (gdc, html)
    - Add support for Markdown checkbox lists. (gdc)
    - Fixes handling of superscript/subscript to close old styles before opening new style. 
       Moves opening superscript/subscript later in process. (gdc)
    - Added center/right alignment to HTML paragraph and heading handling. 
       Will add text-align: center/right depending on paragraph formatting. (html, gdc)
*/
```
