### PR TITLE
Close footnote tags

### DIFF
--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -1356,7 +1356,7 @@ gdc.maybeCloseAttrs = function(currentAttrs) {
         }
         gdc.writeStringToBuffer(gdc.markup.codeClose);
         // We probably don't want to continue using mixed markup.
-        gdc.resetMarkup();
+        gdc.resetMarkup
       }
     }
     // Close bold.
@@ -1942,6 +1942,8 @@ md.handleParagraph = function(para) {
     if (gdc.inCodeBlock) {
       // do nothing: we also want to not add the tablePrefix.
       // But check for table cell or definition list.
+    } else if (gdc.isFootnote) {
+      // Do nothing. We don't want to open a paragraph  
     } else if (!gdc.startingTableCell && !gdc.inDlist) {
       // This is where we want to check for right/center alignment so that the proper paragraph style can be applied. 
       if (gdc.isHTML && para.getAlignment() === DocumentApp.HorizontalAlignment.RIGHT && para.isLeftToRight()) {

--- a/addon/gdc.gs
+++ b/addon/gdc.gs
@@ -52,9 +52,10 @@ gdc.banner = '<!-- NOTICE: Google recently added tabs to Google Docs: '
 var DEBUG = false;
 var LOG = false;
 var GDC_TITLE = 'Docs to Markdown'; // formerly GD2md-html, formerly gd2md-html
-var GDC_VERSION = '1.0β40'; // based on 1.0β39'
+var GDC_VERSION = '1.0β41'; // based on 1.0β40'
 
 // Version notes: significant changes (latest on top). (files changed)
+// - 1.0β41 (8 May 2025): Closes <li> tag in footnotes. When writing footnote content, does not open a <p> tag. (gdc, html)
 /** - 1.0β40 (13 Oct 2024): 
     - Close list items before opening a new item. Close at the end of the list. (gdc, html)
     - Add support for Markdown checkbox lists. (gdc)

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -1,3 +1,5 @@
+// *** html.gs ***
+
 /*
  * Copyright 2020 Google LLC
  *
@@ -112,6 +114,10 @@ html.doHtml = function(config) {
     // But notify if there are errors.
     gdc.out = '<!-- ' + gdc.errorSummary + ' -->\n' + gdc.out;
   }
+
+  // Always include the banner.
+  gdc.out = gdc.banner + gdc.out;
+
   
   // Output content.
   gdc.flushBuffer();

--- a/addon/html.gs
+++ b/addon/html.gs
@@ -1,5 +1,3 @@
-// *** html.gs ***
-
 /*
  * Copyright 2020 Google LLC
  *
@@ -114,10 +112,6 @@ html.doHtml = function(config) {
     // But notify if there are errors.
     gdc.out = '<!-- ' + gdc.errorSummary + ' -->\n' + gdc.out;
   }
-
-  // Always include the banner.
-  gdc.out = gdc.banner + gdc.out;
-
   
   // Output content.
   gdc.flushBuffer();
@@ -488,9 +482,9 @@ html.handleFootnote = function(footnote) {
   }
   // Each HTML footnote is a list item in an ordered list:
   gdc.writeStringToBuffer('<li id="fn' + gdc.footnoteNumber + '">');
-  md.childLoop(fSection);
-  // Close footnote with a link back to the ref.
-  gdc.writeStringToBuffer('&nbsp;<a href="#fnref' + gdc.footnoteNumber + '" rev="footnote">&#8617;</a>');
+  md.childLoop(fSection); // Adds footnote text, plus an extra paragraph tag. How do we avoid opening an unclosed paragraph in these footnote items?
+  // Close footnote with a link back to the ref. Remember to close the tag. 
+  gdc.writeStringToBuffer('&nbsp;<a href="#fnref' + gdc.footnoteNumber + '" rev="footnote">&#8617;</a></li>');
   gdc.isFootnote = false;
 };
 


### PR DESCRIPTION
Closes li tags in footnotes which resolves some issues with some CMSs. 

There is still a paragraph tag opened before the footnote content which may need to be resolved, but I'm not sure how to at this point. 